### PR TITLE
Fix TabBar scroll

### DIFF
--- a/packages/graphql-playground/src/components/Playground/TabBar.tsx
+++ b/packages/graphql-playground/src/components/Playground/TabBar.tsx
@@ -79,7 +79,6 @@ export const TabBar = withTheme<
 
           .tabs {
             @p: .mt16, .ml16, .flex, .itemsCenter, .z0, .overflowAuto;
-            height: 41px;
             margin-right: 200px;
           }
 


### PR DESCRIPTION
I found that this height causes scroll in Chrome running on Windows 10.

![Scroll Issue](https://user-images.githubusercontent.com/7361642/31049628-945e7a3c-a63f-11e7-9603-14207a6f95e6.jpg)
