### PR TITLE
🎉 Move enum comments under the value

### DIFF
--- a/packages/graphql-playground/src/components/Playground/DocExplorer/DocsTypes/EnumTypeSchema.tsx
+++ b/packages/graphql-playground/src/components/Playground/DocExplorer/DocsTypes/EnumTypeSchema.tsx
@@ -25,7 +25,7 @@ const EnumTypeSchema = ({ type }: EnumTypeSchemaProps) => {
       <span className="brace">{'{'}</span>
       {values
         .filter((value: any) => !value.isDeprecated)
-        .map(value => <Value key={value.name} value={value} />)}
+        .map((value, index) => <Value key={value.name} first={index === 0} value={value} />)}
       {deprecatedValues.length > 0 && <br />}
       {deprecatedValues.map(value =>
         <Value key={value.name} value={value} isDeprecated={true} />,
@@ -40,18 +40,28 @@ export default EnumTypeSchema
 interface ValueProps {
   value: any
   isDeprecated?: boolean
+  first: boolean
 }
 
-const Value = ({ value, isDeprecated }: ValueProps) =>
+const Value = ({ value, isDeprecated, first }: ValueProps) =>
   <div className="doc-value">
     <style jsx={true}>{`
       .doc-value .field-name {
         @p: .ph16;
       }
+      .field-name {
+        padding-top: 6px;
+      }
+      .field-name--first {
+        padding-top: 0px;
+      }
       .doc-value-comment {
         @p: .ph16, .black50;
       }
     `}</style>
+    <div className={`field-name${first ? ' field-name--first' : ''}`}>
+      {value.name}
+    </div>
     {value.description &&
       <div className="doc-value-comment">
         # {value.description}
@@ -60,7 +70,4 @@ const Value = ({ value, isDeprecated }: ValueProps) =>
       <div className="doc-value-comment">
         # Deprecated: {value.deprecationReason}
       </div>}
-    <div className="field-name">
-      {value.name}
-    </div>
   </div>


### PR DESCRIPTION
- Move the comments to be like Graphiql
- Add padding to field name, so that you can see that the comment is grouped together

I think this is easier to understand after looking at this comparison
![image](https://user-images.githubusercontent.com/5027156/31197998-389607d0-a953-11e7-8d67-bebe8f92f0e3.png)
