### PR TITLE
Fix: express middleware TypeScript error

### DIFF
--- a/packages/graphql-playground/src/middleware/express.ts
+++ b/packages/graphql-playground/src/middleware/express.ts
@@ -12,7 +12,7 @@ export type ExpressPlaygroundMiddleware = (
   next: () => void,
 ) => void
 
-export type Register = (options) => ExpressPlaygroundMiddleware
+export type Register = (options: any) => ExpressPlaygroundMiddleware
 
 const express: Register = function voyagerExpress(options) {
   const middlewareOptions: MiddlewareOptions = {


### PR DESCRIPTION
Added a type to the register argument, 'options', which fixes the following error when using the graphql-playground as an express middleware in TypeScript:

```
ERROR in /app/node_modules/graphql-playground/middleware/express.d.ts
(4,33): error TS7006: Parameter 'options' implicitly has an 'any' type.
```