### PR TITLE
Adds contributing guidelines, issue template, and code of conduct.

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,38 @@
+# Contributing to this project
+
+[fork]: https://github.com/graphcool/graphql-playground/fork
+[pr]: https://github.com/graphcool/graphql-playground/compare
+[code-of-conduct]: CODE_OF_CONDUCT.md
+
+Hi there! We're thrilled that you'd like to contribute to this project. Your help is essential for keeping it great.
+
+Please note that this project is released with a [Contributor Code of Conduct][code-of-conduct]. By participating in this project you agree to abide by its terms.
+
+## Contribution Agreement
+
+As a contributor, you represent that the code you submit is your original work or that of your employer (in which case you represent you have the right to bind your employer). By submitting code, you (and, if applicable, your employer) are licensing the submitted code to the open source community subject to the MIT license.
+
+
+## Submitting a pull request
+
+0. [Fork][fork] and clone the repository
+0. Create a new branch: `git checkout -b feature/my-new-feature-name`
+0. Run `npm install` or `yarn install` to make sure you've got the latest dependencies.
+0. Make your change
+0. Run the unit tests and make sure they pass and have 100% coverage. (`npm test`)
+0. Push to your fork and [submit a pull request][pr]
+0. Pat your self on the back and wait for your pull request to be reviewed and merged.
+
+Here are a few things you can do that will increase the likelihood of your pull request being accepted:
+
+- Keep your change as focused as possible. If there are multiple changes you would like to make that are not dependent upon each other, consider submitting them as separate pull requests.
+- Write a [good commit message](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+- In your pull request description, provide as much detail as possible. This context helps the reviewer to understand the motivation for and impact of the change.
+- Make sure that all the unit tests still pass. PRs with failing tests won't be merged.
+
+## Resources
+
+- [How to Contribute to Open Source](https://opensource.guide/how-to-contribute/)
+- [Contributing to Open Source on GitHub](https://guides.github.com/activities/contributing-to-open-source/)
+- [Using Pull Requests](https://help.github.com/articles/about-pull-requests/)
+- [GitHub Help](https://help.github.com)

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,20 @@
+#### This issue pertains to:
+
+- [ ] GraphQL Playground - Electron App
+- [ ] GraphQL Playground
+
+#### What OS and OS version are you experiencing the issue(s) on?
+
+
+#### What version of graphql-playground(-electron) are you experience the issue(s) on?
+
+
+#### What is the expected behavior?
+
+
+#### What is the actual behavior?
+
+
+#### What steps may we take to reproduce the behavior?
+
+

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,46 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at hello@graph.cool. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/


### PR DESCRIPTION
This commit add several items:

1. `CODE_OF_CONDUCT.md` - Code of conduct. Copied from [graphcool/graphcool](https://github.com/graphcool/graphcool/blob/master/CODE_OF_CONDUCT.md).

2. `CONTRIBUTING.md` - Contributing guidelines. Copied from [graphcool/chromeless](https://github.com/graphcool/chromeless/blob/master/CONTRIBUTING.md) repo and modified to update links.

3. `ISSUE_TEMPLATE.md` - Issue template applied when new issues are submitted. This helps structure issue reporting to a normalized level so maintainers can quickly understand the problem and respond.

**Other Notes**:
- The `CONTRIBUTING.md` and `ISSUE_TEMPLATE.md` files have been placed in a `.github` directory to keep from polluting the root. This is allowed by GitHub.

- There is the ability to add a `PULL_REQUEST_TEMPLATE.md` for use on all PRs, also.

- Let me know if you'd like these other documents submitted through PRs, and I'll be glad to help!