### PR TITLE
Add GraphQL file association

### DIFF
--- a/packages/graphql-playground-electron/package.json
+++ b/packages/graphql-playground-electron/package.json
@@ -12,6 +12,16 @@
     "url": "graph.cool"
   },
   "main": "lib/main.js",
+  "build": {
+    "fileAssociations": [
+      {
+        "ext": "graphql",
+        "name": "GraphQL",
+        "description": "GraphQL file",
+        "role": "Editor"
+      }
+    ]
+  },
   "scripts": {
     "build-ts": "rm -rf lib && tsc --target es5",
     "build-webpack": "rm -rf ./dist && NODE_ENV=production GRAPHQL_ENDPOINT=$BACKEND_ADDR/system webpack --config webpack.config.build.js && cp -r static/* dist",

--- a/packages/graphql-playground-electron/src/ElectronApp.tsx
+++ b/packages/graphql-playground-electron/src/ElectronApp.tsx
@@ -190,8 +190,32 @@ export default class ElectronApp extends React.Component<{}, State> {
     }
   }
 
-  readOpenSelectedFileMessage(event, selectedFile) {
+  readOpenSelectedFileMessage = (event, selectedFile) => {
     if (selectedFile) this.openFile(selectedFile)
+  }
+
+  openFile(fileToOpen: string) {
+    const query = fs.readFileSync(fileToOpen, 'utf-8')
+    const rc = this.getGraphcoolRc()
+
+    if (rc && rc.platformToken) {
+      this.setState({ platformToken: rc.platformToken }, () => {
+        this.playground.fetchPermissionSchema()
+        this.playground.fetchServiceInformation()
+      })
+      localStorage.setItem('platformToken', rc.platformToken)
+    }
+
+    const permissionSession = this.getPermissionSessionForPath(
+      fileToOpen,
+    )
+
+    this.playground.newPermissionTab(
+      permissionSession,
+      path.basename(fileToOpen),
+      fileToOpen,
+      query,
+    )
   }
 
   showOpenDialog() {
@@ -208,32 +232,6 @@ export default class ElectronApp extends React.Component<{}, State> {
         this.openFile(path)
       }
     })
-  }
-
-  openFile(file: string) {
-    if (file) {
-      const query = fs.readFileSync(file, 'utf-8')
-
-      const rc = this.getGraphcoolRc()
-      if (rc && rc.platformToken) {
-        this.setState({ platformToken: rc.platformToken }, () => {
-          this.playground.fetchPermissionSchema()
-          this.playground.fetchServiceInformation()
-        })
-        localStorage.setItem('platformToken', rc.platformToken)
-      }
-
-      const permissionSession = this.getPermissionSessionForPath(
-        file,
-      )
-
-      this.playground.newPermissionTab(
-        permissionSession,
-        path.basename(file),
-        file,
-        query,
-      )
-    }
   }
 
   getSaveFileName(): Promise<string> {

--- a/packages/graphql-playground-electron/src/ElectronApp.tsx
+++ b/packages/graphql-playground-electron/src/ElectronApp.tsx
@@ -170,17 +170,19 @@ export default class ElectronApp extends React.Component<{}, State> {
   componentDidMount() {
     ipcRenderer.on('Tab', this.readTabMessage)
     ipcRenderer.on('File', this.readFileMessage)
+    ipcRenderer.on('OpenSelectedFile', this.readOpenSelectedFileMessage)
   }
 
   componentWillUnmount() {
     ipcRenderer.removeListener('Tab', this.readTabMessage)
     ipcRenderer.removeListener('File', this.readFileMessage)
+    ipcRenderer.removeListener('OpenSelectedFile', this.readOpenSelectedFileMessage)
   }
 
   readFileMessage = (error, message) => {
     switch (message) {
       case 'Open':
-        this.openFile()
+        this.showOpenDialog()
         break
       case 'Save':
         this.saveFile()
@@ -188,42 +190,50 @@ export default class ElectronApp extends React.Component<{}, State> {
     }
   }
 
-  openFile() {
-    dialog.showOpenDialog(
-      {
-        title: 'Choose a .graphql file to edit',
-        properties: ['openFile'],
-        // filters: [{
-        //   name: '*',
-        //   extensions: ['graphql']
-        // }]
-      },
-      fileNames => {
-        if (fileNames && fileNames.length > 0) {
-          const query = fs.readFileSync(fileNames[0], 'utf-8')
+  readOpenSelectedFileMessage(event, selectedFile) {
+    if (selectedFile) this.openFile(selectedFile)
+  }
 
-          const rc = this.getGraphcoolRc()
-          if (rc && rc.platformToken) {
-            this.setState({ platformToken: rc.platformToken }, () => {
-              this.playground.fetchPermissionSchema()
-              this.playground.fetchServiceInformation()
-            })
-            localStorage.setItem('platformToken', rc.platformToken)
-          }
+  showOpenDialog() {
+    dialog.showOpenDialog({
+      title: 'Choose a .graphql file to edit',
+      properties: ['openFile'],
+      // filters: [{
+      //   name: '*',
+      //   extensions: ['graphql']
+      // }]
+    }, fileNames => {
+      if (fileNames && fileNames.length > 0) {
+        let path = fileNames[0]
+        this.openFile(path)
+      }
+    })
+  }
 
-          const permissionSession = this.getPermissionSessionForPath(
-            fileNames[0],
-          )
+  openFile(file: string) {
+    if (file) {
+      const query = fs.readFileSync(file, 'utf-8')
 
-          this.playground.newPermissionTab(
-            permissionSession,
-            path.basename(fileNames[0]),
-            fileNames[0],
-            query,
-          )
-        }
-      },
-    )
+      const rc = this.getGraphcoolRc()
+      if (rc && rc.platformToken) {
+        this.setState({ platformToken: rc.platformToken }, () => {
+          this.playground.fetchPermissionSchema()
+          this.playground.fetchServiceInformation()
+        })
+        localStorage.setItem('platformToken', rc.platformToken)
+      }
+
+      const permissionSession = this.getPermissionSessionForPath(
+        file,
+      )
+
+      this.playground.newPermissionTab(
+        permissionSession,
+        path.basename(file),
+        file,
+        query,
+      )
+    }
   }
 
   getSaveFileName(): Promise<string> {

--- a/packages/graphql-playground-electron/src/ElectronApp.tsx
+++ b/packages/graphql-playground-electron/src/ElectronApp.tsx
@@ -191,7 +191,9 @@ export default class ElectronApp extends React.Component<{}, State> {
   }
 
   readOpenSelectedFileMessage = (event, selectedFile) => {
-    if (selectedFile) this.openFile(selectedFile)
+    if (selectedFile) {
+      this.openFile(selectedFile)
+    }
   }
 
   openFile(fileToOpen: string) {
@@ -228,8 +230,8 @@ export default class ElectronApp extends React.Component<{}, State> {
       // }]
     }, fileNames => {
       if (fileNames && fileNames.length > 0) {
-        let path = fileNames[0]
-        this.openFile(path)
+        const file = fileNames[0]
+        this.openFile(file)
       }
     })
   }

--- a/packages/graphql-playground-electron/src/main.ts
+++ b/packages/graphql-playground-electron/src/main.ts
@@ -277,6 +277,11 @@ app.on('ready', () => {
   })
 })
 
+app.on('open-file', (event, path) => {
+  event.preventDefault()
+  send('OpenSelectedFile', path)
+})
+
 // Quit when all windows are closed.
 app.on('window-all-closed', () => {
   // On OS X it is common for applications and their menu bar


### PR DESCRIPTION
Adds the file association for GraphQL files to allow users to double-click to open a file.

Tested on macOS High Sierra

Closes #50