### PR TITLE
include credentials when fetching schema

### DIFF
--- a/packages/graphql-playground/src/components/Playground.tsx
+++ b/packages/graphql-playground/src/components/Playground.tsx
@@ -335,6 +335,7 @@ export class Playground extends React.PureComponent<Props & DocsState, State> {
   fetchSchema(endpointUrl: string, headers: any = {}) {
     return fetch(endpointUrl, {
       method: 'post',
+      credentials: 'include',
       headers: {
         'Content-Type': 'application/json',
         'X-Apollo-Tracing': '1',


### PR DESCRIPTION
This tells fetch to include credentials when making the introspection query as well as other querires. Similar PR to https://github.com/graphcool/graphql-playground/pull/174

This is necessary for setups where every request gets routed through an auth path. 

/cc @wzrdzl @timsuchanek @kbrandwijk @schickling @morajabi 