### PR TITLE
WIP: Auto-complete description

### DIFF
--- a/packages/graphql-playground/src/components/Playground/QueryEditor.tsx
+++ b/packages/graphql-playground/src/components/Playground/QueryEditor.tsx
@@ -147,6 +147,11 @@ export class QueryEditor extends React.Component<Props, {}> {
     if (this.props.schema !== prevProps.schema) {
       this.editor.options.lint.schema = this.props.schema
       this.editor.options.hintOptions.schema = this.props.schema
+      if (this.props.schema) {
+        this.editor.options.hintOptions.schema.getType = type => {
+          return type
+        }
+      }
       CodeMirror.signal(this.editor, 'change', this.editor)
     }
     if (

--- a/packages/graphql-playground/src/components/Playground/onHasCompletion.tsx
+++ b/packages/graphql-playground/src/components/Playground/onHasCompletion.tsx
@@ -6,7 +6,7 @@
  *  LICENSE file in the root directory of this source tree.
  */
 
-import { GraphQLNonNull, GraphQLList } from 'graphql'
+// import { GraphQLNonNull, GraphQLList } from 'graphql'
 import * as marked from 'marked'
 
 /**
@@ -93,7 +93,7 @@ export default function onHasCompletion(cm, data, onHintInformationRender) {
     // Now that the UI has been set up, add info to information.
     const description = ctx.description
       ? marked(ctx.description, { sanitize: true })
-      : 'Self descriptive.'
+      : ''
     const type = ctx.type
       ? '<span class="infoType">' + renderType(ctx.type) + '</span>'
       : ''
@@ -124,11 +124,11 @@ export default function onHasCompletion(cm, data, onHintInformationRender) {
 }
 
 function renderType(type) {
-  if (type instanceof GraphQLNonNull) {
-    return `${renderType(type.ofType)}!`
-  }
-  if (type instanceof GraphQLList) {
-    return `[${renderType(type.ofType)}]`
-  }
-  return `<a class="typeName">${type.name}</a>`
+  // if (type instanceof GraphQLNonNull) {
+  //   return `${renderType(type.ofType)}!`
+  // }
+  // if (type instanceof GraphQLList) {
+  //   return `[${renderType(type.ofType)}]`
+  // }
+  return `<a class="typeName">${type}</a>`
 }


### PR DESCRIPTION
This should fix #307, it takes type from `codemirror-graphql/hint` and just prints it. Because hint already returns correct type. I can refactor it somewhere and remove commented out parts.