### PR TITLE
Make 'credentials' configurable for GQL requests

### DIFF
--- a/packages/graphql-playground-react/src/components/MiddlewareApp.tsx
+++ b/packages/graphql-playground-react/src/components/MiddlewareApp.tsx
@@ -67,6 +67,7 @@ const defaultSettings = `{
   "general.betaUpdates": false,
   "editor.theme": "dark",
   "editor.reuseHeaders": true,
+  "request.credentials": "omit",
   "tracing.hideTracingResponse": true
 }`
 

--- a/packages/graphql-playground-react/src/components/Playground.tsx
+++ b/packages/graphql-playground-react/src/components/Playground.tsx
@@ -1016,8 +1016,7 @@ export class Playground extends React.PureComponent<Props & DocsState, State> {
       // tslint:disable-lin
       method: 'post',
       headers,
-      // TODO enable
-      // credentials: 'include',
+      credentials: this.props.settings["request.credentials"],
       body: JSON.stringify(graphQLParams),
     }).then(response => {
       if (typeof this.props.onSuccess === 'function') {


### PR DESCRIPTION
This PR fixes #364

## The cause of the issue

The issue was due to [this](https://github.com/graphcool/graphql-playground/blame/0eb2492545d8c58de80eb8e435840e3fadc144b2/packages/graphql-playground-react/src/components/Playground.tsx#L1020). Tim must've commented that out because having `credentials: "include"` by default is not best practice, as it breaks requests to any server that does not have the correct `cors` options set up. Specifically, a server must know the domains of all the requesters in advance when `credentials: "include"`.

## The proposed change

The change proposed here is very simple: 

- I have added `request.credentials: "omit"` to the default settings
- The new option only affects the `fetch()` call used to "post" GraphQL queries/mutations to the server

By having `"omit"` as a default setting, I preserve the current behaviour: no request will be broken due to lack of the correct `cors` options server-side. 

Additionally, `request.credentials` can take all the values that `credentials` for `fetch()` [takes](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch): 

- `"omit"`
- `"include"`
- `"same-origin"`

Of course, one must know what they are doing, as the server must have `cors` enabled and correctly configured. The `same-origin` value comes in handy for those project like the one I am working on right now, where we use an express middleware, so client and server are on the same domain. Also, our official "client", when ready, will also be living on the same domain. The `include` value can be set for all other scenarios where the client lives on a different domain than the server and one can tell the server what "client domains" to allow.

## Tested

I have tested this locally pointing the react app to my server (correctly configured for each of the `credentials` values) and all seems to be working just fine.

## Potential improvements

- It might be that `Settings` is not exactly the best place to put this setting in, but I do believe that it is a good enough choice for the time being.

- Expose the settings to the middlewares so that they can instantiate the Playground with the option for "credentials" that it is best for their project. 

  
  
  
  