### PR TITLE
Fixed link to documentation type broken

### DIFF
--- a/packages/graphql-playground-react/src/components/Playground/DocExplorer/GraphDocs.tsx
+++ b/packages/graphql-playground-react/src/components/Playground/DocExplorer/GraphDocs.tsx
@@ -254,6 +254,16 @@ class GraphDocs extends React.Component<
     )
   }
 
+  public showDocFromType = (type) => {
+    this.props.toggleDocs(this.props.sessionId, true);
+    this.props.addStack(
+      this.props.sessionId,
+      type,
+      0,
+      0
+    )
+  }
+
   private setDocExplorerRef = ref => {
     this.refDocExplorer = ref
   }
@@ -426,4 +436,6 @@ const mapDispatchToProps = dispatch =>
 export default connect<StateFromProps, DispatchFromProps, Props>(
   getSessionDocs,
   mapDispatchToProps,
+  null,
+  { withRef: true }
 )(GraphDocs)

--- a/packages/graphql-playground-react/src/components/Playground/GraphQLEditor.tsx
+++ b/packages/graphql-playground-react/src/components/Playground/GraphQLEditor.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import * as ReactDOM from 'react-dom'
-import { parse, print, GraphQLSchema } from 'graphql'
+import { parse, print, GraphQLSchema, isNamedType } from 'graphql'
 import * as cn from 'classnames'
 import ExecuteButton from './ExecuteButton'
 import { QueryEditor } from './QueryEditor'
@@ -19,7 +19,7 @@ import Spinner from '../Spinner'
 import Results from './Results'
 import ReponseTracing from './ResponseTracing'
 import withTheme from '../Theme/withTheme'
-import { LocalThemeInterface } from '../Theme/index'
+import { LocalThemeInterface } from '../Theme'
 import GraphDocs from './DocExplorer/GraphDocs'
 import { SchemaFetcher } from './SchemaFetcher'
 import { setStacks } from '../../actions/graphiql-docs'
@@ -105,13 +105,11 @@ export interface State {
   variableEditorHeight: number
   responseTracingOpen: boolean
   responseTracingHeight: number
-  docExploreOpen: boolean
   docExplorerWidth: number
   isWaitingForReponse: boolean
   subscription: any
   variableToType: any
   operations: any[]
-  docExplorerOpen: boolean
   schemaExplorerOpen: boolean
   schemaExplorerWidth: number
   isWaitingForResponse: boolean
@@ -244,7 +242,6 @@ export class GraphQLEditor extends React.PureComponent<
       responseTracingOpen: false,
       responseTracingHeight:
         Number(this.storageGet('responseTracingHeight')) || 300,
-      docExplorerOpen: false,
       docExplorerWidth: Number(this.storageGet('docExplorerWidth')) || 350,
       schemaExplorerOpen: false,
       schemaExplorerWidth:
@@ -626,6 +623,11 @@ export class GraphQLEditor extends React.PureComponent<
           </div>
         </div>
         <GraphDocs
+          ref={(ref: any) => {
+            if (ref) {
+              this.docExplorerComponent = ref.getWrappedInstance()
+            }
+          }}
           schema={this.state.schema!}
           sessionId={this.props.session.id}
         />
@@ -1269,11 +1271,14 @@ export class GraphQLEditor extends React.PureComponent<
       const typeName = event.target.innerHTML
       const schema = this.state.schema
       if (schema) {
-        const type = schema.getType(typeName)
-        if (type) {
-          this.setState({ docExplorerOpen: true } as State, () => {
-            this.docExplorerComponent.showDoc(type)
-          })
+        // TODO: There is no way as of now to retrieve the NAMED_TYPE of a GraphQLList(Type).
+        // We're therefore removing any '[' or '!' characters, to properly find its NAMED_TYPE. (eg. [Type!]! => Type)
+        // This should be removed as soon as there's a safer way to do that.
+        const namedTypeName = typeName.replace(/[\]\[!]/g, '')
+        const type = schema.getType(namedTypeName)
+
+        if (isNamedType(type)) {
+          this.docExplorerComponent.showDocFromType(type)
         }
       }
     }

--- a/packages/graphql-playground-react/src/components/Playground/GraphQLEditor.tsx
+++ b/packages/graphql-playground-react/src/components/Playground/GraphQLEditor.tsx
@@ -623,11 +623,7 @@ export class GraphQLEditor extends React.PureComponent<
           </div>
         </div>
         <GraphDocs
-          ref={(ref: any) => {
-            if (ref) {
-              this.docExplorerComponent = ref.getWrappedInstance()
-            }
-          }}
+          ref={this.setDocExplorerRef}
           schema={this.state.schema!}
           sessionId={this.props.session.id}
         />
@@ -705,6 +701,12 @@ export class GraphQLEditor extends React.PureComponent<
 
   setResultComponent = ref => {
     this.resultComponent = ref
+  }
+
+  setDocExplorerRef = ref => {
+    if (ref) {
+      this.docExplorerComponent = ref.getWrappedInstance()
+    }
   }
 
   handleClickReference = reference => {


### PR DESCRIPTION
Fixes #495.

Changes proposed in this pull request:

Links shown at the bottom of the autocomplete dropdown were crashing the app everytime.
It should now be fixed, opening the schema explorer everytime we click the links.
The `navStack` is reseted, showing only one tab with the documentation of the type only.

I removed all references to `docExplorerOpen` as it was dead code coming from the original GraphiQL component.

Some tests would be very welcome !

<img width="653" alt="capture d ecran 2018-01-22 a 15 56 02" src="https://user-images.githubusercontent.com/25233379/35226856-d19037d2-ff8c-11e7-8a1f-4e5626bc3f23.png">
