### PR TITLE
Correctly use cookies when fetching schema

### DIFF
--- a/packages/graphql-playground-react/src/components/Playground/SchemaFetcher.ts
+++ b/packages/graphql-playground-react/src/components/Playground/SchemaFetcher.ts
@@ -28,10 +28,10 @@ export class SchemaFetcher {
   ): Promise<{ schema: GraphQLSchema; tracingSupported: boolean } | null> {
     const response = await fetch(endpoint, {
       method: 'post',
+      credentials: 'include',
       headers: {
         'Content-Type': 'application/json',
         'X-Apollo-Tracing': '1',
-        credentials: 'include',
         ...headers,
       },
       body: JSON.stringify({ query: introspectionQuery }),


### PR DESCRIPTION
This implementation currently fails to send cookies along with a request (even though that was intended).

This is because `credentials: include` is included in the list of headers rather than being passed as an option.

Fixes #505

Changes proposed in this pull request:

- Move `credentials: include` from improperly being sent in headers to being passed as an option when fetching schema.