### PR TITLE
Adding docs link

### DIFF
--- a/packages/graphql-playground-react/src/components/Playground/GraphQLEditor.tsx
+++ b/packages/graphql-playground-react/src/components/Playground/GraphQLEditor.tsx
@@ -702,7 +702,7 @@ export class GraphQLEditor extends React.PureComponent<
   }
 
   handleClickReference = reference => {
-    //
+    this.docExplorerComponent.showDocFromType(reference.field)
   }
 
   /**

--- a/packages/graphql-playground-react/src/styles/graphiql_dark.css
+++ b/packages/graphql-playground-react/src/styles/graphiql_dark.css
@@ -1296,6 +1296,10 @@ span.CodeMirror-selectedtext {
   z-index: 100;
 }
 
+.CodeMirror-jump-token {
+  text-decoration: underline;
+}
+
 .CodeMirror-lint-mark-error,
 .CodeMirror-lint-mark-warning {
   background-position: left bottom;

--- a/packages/graphql-playground-react/src/styles/graphiql_light.css
+++ b/packages/graphql-playground-react/src/styles/graphiql_light.css
@@ -1326,6 +1326,10 @@ p:first-child,
   z-index: 100;
 }
 
+.docs-graphiql .CodeMirror-jump-token {
+  text-decoration: underline;
+}
+
 .docs-graphiql .CodeMirror-lint-mark-error,
 .CodeMirror-lint-mark-warning {
   background-position: left bottom;


### PR DESCRIPTION
Fixes #88.

Changes proposed in this pull request:
Adding link to docs, currently opens in 2nd column for everything idk how we want to show it.
![](https://i.imgur.com/vnKyBcQ.gif)
