### PR TITLE
Add ability to disable share button

### DIFF
--- a/packages/graphql-playground-react/src/components/Playground.tsx
+++ b/packages/graphql-playground-react/src/components/Playground.tsx
@@ -59,6 +59,7 @@ export interface Props {
   endpoint: string
   subscriptionEndpoint?: string
   projectId?: string
+  shareEnabled?: boolean
   adminAuthToken?: string
   onSuccess?: (graphQLParams: any, response: any) => void
   isEndpoint?: boolean
@@ -123,6 +124,10 @@ export interface CursorPosition {
 export { GraphQLEditor }
 
 export class Playground extends React.PureComponent<Props & ReduxProps, State> {
+  static defaultProps = {
+    shareEnabled: true,
+  }
+
   apolloLinks: { [sessionId: string]: any } = {}
   observers: { [sessionId: string]: any } = {}
   graphiqlComponents: any[] = []
@@ -277,7 +282,10 @@ export class Playground extends React.PureComponent<Props & ReduxProps, State> {
             ) : this.props.isFile && this.props.file ? (
               <FileEditor />
             ) : (
-              <GraphQLEditor schema={this.state.schema} />
+              <GraphQLEditor
+                shareEnabled={this.props.shareEnabled}
+                schema={this.state.schema}
+              />
             )}
           </GraphiqlWrapper>
         </GraphiqlsContainer>

--- a/packages/graphql-playground-react/src/components/Playground/GraphQLEditor.tsx
+++ b/packages/graphql-playground-react/src/components/Playground/GraphQLEditor.tsx
@@ -67,6 +67,7 @@ import { ResponseRecord } from '../../state/sessions/reducers'
 
 export interface Props {
   onRef?: any
+  shareEnabled?: boolean
   schema?: GraphQLSchema
 }
 
@@ -248,7 +249,7 @@ class GraphQLEditor extends React.PureComponent<
           }
         `}</style>
         <div className="editorWrap">
-          <TopBar />
+          <TopBar shareEnabled={this.props.shareEnabled} />
           <div
             ref={this.setEditorBarComponent}
             className="editorBar"

--- a/packages/graphql-playground-react/src/components/Playground/TopBar/TopBar.tsx
+++ b/packages/graphql-playground-react/src/components/Playground/TopBar/TopBar.tsx
@@ -28,6 +28,7 @@ import { openHistory } from '../../../state/general/actions'
 
 export interface Props {
   endpoint: string
+  shareEnabled?: boolean
   fixedEndpoint?: boolean
   isReloadingSchema: boolean
   endpointUnreachable: boolean
@@ -75,9 +76,11 @@ class TopBar extends React.Component<Props, {}> {
           )}
         </UrlBarWrapper>
         <Button onClick={this.copyCurlToClipboard}>Copy CURL</Button>
-        <Share>
-          <Button>Share Playground</Button>
-        </Share>
+        {this.props.shareEnabled && (
+          <Share>
+            <Button>Share Playground</Button>
+          </Share>
+        )}
       </TopBarWrapper>
     )
   }


### PR DESCRIPTION
Changes proposed in this pull request:

- I would like to use graphql-playground on a project that has strict security requirements, and the share button's external request violates our rules. This pr exposes a prop called `shareEnabled` that will allow you to disable the share button.

