### PR TITLE
Set credentials when creating HttpLink

### DIFF
--- a/packages/graphql-playground-react/src/state/sessions/fetchingSagas.ts
+++ b/packages/graphql-playground-react/src/state/sessions/fetchingSagas.ts
@@ -30,7 +30,7 @@ import {
   getParsedVariablesFromSession,
 } from './selectors'
 import { SchemaFetcher } from '../../components/Playground/SchemaFetcher'
-import { getSelectedWorkspaceId } from '../workspace/reducers'
+import { getSelectedWorkspaceId, getSettings } from '../workspace/reducers'
 import * as cuid from 'cuid'
 import { Session, ResponseRecord } from './reducers'
 import { addHistoryItem } from '../history/actions'
@@ -47,6 +47,7 @@ export function setSubscriptionEndpoint(endpoint) {
 export interface LinkCreatorProps {
   endpoint: string
   headers?: Headers
+  credentials?: string
 }
 
 export interface Headers {
@@ -58,7 +59,7 @@ export const defaultLinkCreator = (
   wsEndpoint?: string,
 ): { link: ApolloLink; subscriptionClient?: SubscriptionClient } => {
   let connectionParams = {}
-  const { headers } = session
+  const { headers, credentials } = session
 
   if (headers) {
     connectionParams = { ...headers }
@@ -68,6 +69,7 @@ export const defaultLinkCreator = (
     uri: session.endpoint,
     fetch,
     headers,
+    credentials,
   })
 
   if (!(wsEndpoint || subscriptionEndpoint)) {
@@ -122,6 +124,7 @@ function* runQuerySaga(action) {
   const operation = makeOperation(request)
   const operationIsSubscription = isSubscription(operation)
   const workspace = yield select(getSelectedWorkspaceId)
+  const settings = yield select(getSettings)
   yield put(setSubscriptionActive(isSubscription(operation)))
   yield put(startQuery())
   let headers = parseHeaders(session.headers)
@@ -131,6 +134,7 @@ function* runQuerySaga(action) {
   const { link, subscriptionClient } = linkCreator({
     endpoint: session.endpoint,
     headers,
+    credentials: settings['request.credentials'],
   })
   yield put(setCurrentQueryStartTime(new Date()))
 


### PR DESCRIPTION
It's possible to set "credentials" option in the GraphQL Playground settings. But it seems that this option is not used when HttpLink is created. This causes problems when user relies on the cookies, e.g. uses cookies for authentication.

Related issues:
https://github.com/graphcool/graphql-playground/issues/656
https://github.com/graphcool/graphql-playground/issues/681

Previous PR with the fix, when regular fetch was used:
https://github.com/graphcool/graphql-playground/pull/470

I've encountered this issue myself, since I'm using cookies for storing session ID. I verified that my API works as expected with GraphiQL (i.e. cookies are being sent). Today was the first time that I've read the Playground's code, so I'm not aware of the conventions etc. I see that there's some refactor going on so tell me how to adapt the code to adhere to the standards.

Also, in the ideal case I think that this PR needs a unit test, since it regressed, but I don't have enough time today.